### PR TITLE
Break out menu alignment examples.

### DIFF
--- a/src/partials/navigation-menus.html
+++ b/src/partials/navigation-menus.html
@@ -49,6 +49,7 @@ By default, menu items align to the left. They can also be aligned to the right 
     <li><a href="#">Four</a></li>
   </ul>
 </div>
+
 ```
 <ul class="menu align-right">...</ul>
 ```
@@ -60,6 +61,7 @@ By default, menu items align to the left. They can also be aligned to the right 
     <li><a href="#">Four</a></li>
   </ul>
 </div>
+
 ```
 <ul class="menu align-center">...</ul>
 ```
@@ -71,6 +73,7 @@ By default, menu items align to the left. They can also be aligned to the right 
     <li><a href="#">Four</a></li>
   </ul>
 </div>
+
 ```
 <ul class="menu expanded">...</ul>
 ```

--- a/src/partials/navigation-menus.html
+++ b/src/partials/navigation-menus.html
@@ -40,9 +40,6 @@ By default, menu items align to the left. They can also be aligned to the right 
 
 ```
 <ul class="menu">...</ul>
-<ul class="menu align-right">...</ul>
-<ul class="menu align-center">...</ul>
-<ul class="menu expanded">...</ul>
 ```
 <div class="callout">
   <ul class="menu">
@@ -51,18 +48,33 @@ By default, menu items align to the left. They can also be aligned to the right 
     <li><a href="#">Three</a></li>
     <li><a href="#">Four</a></li>
   </ul>
+</div>
+```
+<ul class="menu align-right">...</ul>
+```
+<div class="callout">
   <ul class="menu align-right">
     <li><a href="#">One</a></li>
     <li><a href="#">Two</a></li>
     <li><a href="#">Three</a></li>
     <li><a href="#">Four</a></li>
   </ul>
+</div>
+```
+<ul class="menu align-center">...</ul>
+```
+<div class="callout">
   <ul class="menu align-center">
     <li><a href="#">One</a></li>
     <li><a href="#">Two</a></li>
     <li><a href="#">Three</a></li>
     <li><a href="#">Four</a></li>
   </ul>
+</div>
+```
+<ul class="menu expanded">...</ul>
+```
+<div class="callout">
   <ul class="menu expanded">
     <li><a href="#">One</a></li>
     <li><a href="#">Two</a></li>


### PR DESCRIPTION
Just a minor suggestion. The formatting of the menu alignment section stuck out to me as difficult to parse, initially. This PR would make it go from this . . .

![Screen Shot 2020-01-14 at 4 37 16 PM](https://user-images.githubusercontent.com/662963/72385112-c6942200-36ec-11ea-8db2-4588d58ed96a.png)

. . . to this: 

![Screen Shot 2020-01-14 at 4 41 17 PM](https://user-images.githubusercontent.com/662963/72385130-d01d8a00-36ec-11ea-8d9a-33a5de985842.png)
